### PR TITLE
Unify separator for script files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <repository>
             <id>kbss</id>
             <name>KBSS Maven 2 Repository</name>
-            <url>http://kbss.felk.cvut.cz/m2repo</url>
+            <url>https://kbss.felk.cvut.cz/m2repo</url>
             <snapshots>
                 <checksumPolicy>ignore</checksumPolicy>
                 <enabled>true</enabled>
@@ -51,7 +51,7 @@
         <repository>
             <id>topquadrant</id>
             <name>topquadrant Repository</name>
-            <url>http://topquadrant.com/repository/spin/</url>
+            <url>https://archive.topquadrant.com/repository/spin/</url>
             <snapshots>
                 <checksumPolicy>ignore</checksumPolicy>
                 <enabled>true</enabled>

--- a/src/main/java/og_spipes/config/Constants.java
+++ b/src/main/java/og_spipes/config/Constants.java
@@ -1,0 +1,5 @@
+package og_spipes.config;
+
+public class Constants {
+    public static final String SCRIPTPATH_SPEL = "#{'${scriptPaths}'.split(';')}";
+}

--- a/src/main/java/og_spipes/persistence/dao/ScriptDAO.java
+++ b/src/main/java/og_spipes/persistence/dao/ScriptDAO.java
@@ -7,6 +7,7 @@ import cz.cvut.kbss.jopa.model.JOPAPersistenceProperties;
 import cz.cvut.kbss.jopa.model.JOPAPersistenceProvider;
 import cz.cvut.kbss.ontodriver.jena.JenaDataSource;
 import cz.cvut.kbss.ontodriver.jena.config.JenaOntoDriverProperties;
+import og_spipes.config.Constants;
 import og_spipes.model.AbstractEntitySP;
 import og_spipes.model.Vocabulary;
 import og_spipes.model.spipes.FunctionDTO;
@@ -42,7 +43,7 @@ public class ScriptDAO {
     final EntityManagerFactory emf;
 
     //TODO try to use created EM - check if working while editing
-    public ScriptDAO(@Value("${scriptPaths}") String[] scriptPaths) {
+    public ScriptDAO(@Value(Constants.SCRIPTPATH_SPEL) String[] scriptPaths) {
         final Map<String, String> props = new HashMap<>();
         // Here we set up basic storage access properties - driver class, physical location of the storage
         props.put(JOPAPersistenceProperties.ONTOLOGY_PHYSICAL_URI_KEY, "local://temporary"); // jopa uses the URI scheme to choose between local and remote repo, file and (http, https and ftp)resp.

--- a/src/main/java/og_spipes/rest/ScriptController.java
+++ b/src/main/java/og_spipes/rest/ScriptController.java
@@ -2,6 +2,7 @@ package og_spipes.rest;
 
 import cz.cvut.kbss.jsonld.JsonLd;
 import cz.cvut.kbss.jsonld.exception.TargetTypeException;
+import og_spipes.config.Constants;
 import og_spipes.model.dto.*;
 import og_spipes.model.filetree.SubTree;
 import og_spipes.model.spipes.DependencyDTO;
@@ -43,7 +44,7 @@ public class ScriptController {
 
     private static final Logger LOG = LoggerFactory.getLogger(ScriptController.class);
 
-    @Value("${scriptPaths}")
+    @Value(Constants.SCRIPTPATH_SPEL)
     private String[] scriptPaths;
 
     @Value("${scriptRules}")

--- a/src/main/java/og_spipes/service/SHACLExecutorService.java
+++ b/src/main/java/og_spipes/service/SHACLExecutorService.java
@@ -1,6 +1,7 @@
 package og_spipes.service;
 
 import com.google.common.collect.Sets;
+import og_spipes.config.Constants;
 import og_spipes.model.dto.SHACLValidationResultDTO;
 import og_spipes.service.util.ScriptImportGroup;
 import og_spipes.shacl.Validator;
@@ -37,7 +38,7 @@ public class SHACLExecutorService {
 
     private final String[] scriptPaths;
 
-    public SHACLExecutorService(@Value("${scriptPaths}") String[] scriptPaths) {
+    public SHACLExecutorService(@Value(Constants.SCRIPTPATH_SPEL) String[] scriptPaths) {
         this.scriptPaths = scriptPaths;
     }
 

--- a/src/main/java/og_spipes/websocket/NotificationHandler.java
+++ b/src/main/java/og_spipes/websocket/NotificationHandler.java
@@ -1,6 +1,7 @@
 package og_spipes.websocket;
 
 
+import og_spipes.config.Constants;
 import org.apache.commons.io.monitor.FileAlterationListener;
 import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
 import org.apache.commons.io.monitor.FileAlterationMonitor;
@@ -32,7 +33,7 @@ public class NotificationHandler extends TextWebSocketHandler implements Initial
     private static final Logger LOG = LoggerFactory.getLogger(NotificationHandler.class);
     private static final Map<String, Set<WebSocketSession>> fileSubscribers = Collections.synchronizedMap(new HashMap<>());
 
-    @Value("${scriptPaths}")
+    @Value(Constants.SCRIPTPATH_SPEL)
     private String[] scriptPaths;
 
     @Override

--- a/src/test/java/og_spipes/config/CustomParsingScriptPathParameterTest.java
+++ b/src/test/java/og_spipes/config/CustomParsingScriptPathParameterTest.java
@@ -1,0 +1,23 @@
+package og_spipes.config;
+
+import og_spipes.service.SHACLExecutorService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+        // TODO - remove bean dependency
+        classes = {SHACLExecutorService.class}, // reduce dependency of test to other beans
+        properties = {"scriptPaths=/tmp/og_spipes;/tmp/og_spipes1"} // tested balue
+)
+public class CustomParsingScriptPathParameterTest {
+    @Value(Constants.SCRIPTPATH_SPEL)
+    private String[] scriptPaths;
+
+
+    @Test
+    void testImport(){
+        Assertions.assertEquals(2, scriptPaths.length);
+    }
+}

--- a/src/test/java/og_spipes/persistence/dao/ScriptDAOTest.java
+++ b/src/test/java/og_spipes/persistence/dao/ScriptDAOTest.java
@@ -20,8 +20,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-
 @SpringBootTest
 public class ScriptDAOTest {
 

--- a/src/test/java/og_spipes/rest/ExecutionControllerTest.java
+++ b/src/test/java/og_spipes/rest/ExecutionControllerTest.java
@@ -1,6 +1,7 @@
 package og_spipes.rest;
 
 import com.google.common.collect.Sets;
+import og_spipes.config.Constants;
 import og_spipes.service.ModuleExecutionInfo;
 import og_spipes.service.ViewService;
 import org.apache.commons.io.FileUtils;
@@ -35,7 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(locations="classpath:application.properties")
 public class ExecutionControllerTest {
 
-    @Value("${scriptPaths}")
+    @Value(Constants.SCRIPTPATH_SPEL)
     private String scriptPaths;
 
     @Mock

--- a/src/test/java/og_spipes/rest/FormControllerTest.java
+++ b/src/test/java/og_spipes/rest/FormControllerTest.java
@@ -1,5 +1,6 @@
 package og_spipes.rest;
 
+import og_spipes.config.Constants;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -29,7 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(locations="classpath:application.properties")
 public class FormControllerTest {
 
-    @Value("${scriptPaths}")
+    @Value(Constants.SCRIPTPATH_SPEL)
     private String scriptPaths;
 
     @Autowired

--- a/src/test/java/og_spipes/rest/FunctionControllerTest.java
+++ b/src/test/java/og_spipes/rest/FunctionControllerTest.java
@@ -9,7 +9,7 @@ import og_spipes.service.FormService;
 import og_spipes.service.FunctionService;
 import og_spipes.service.SPipesExecutionService;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,10 +33,11 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
 
 @WebMvcTest(controllers = FunctionController.class)
 @TestPropertySource(locations="classpath:application.properties")
@@ -93,8 +94,8 @@ public class FunctionControllerTest {
 
         List<FunctionDTO> obj = mapper.readValue(content, new TypeReference<List<FunctionDTO>>(){});
 
-        Assert.assertEquals(1, obj.size());
-        Assert.assertEquals("execute-greeding", obj.get(0).getFunctionLocalName());
+        Assertions.assertEquals(1, obj.size());
+        Assertions.assertEquals("execute-greeding", obj.get(0).getFunctionLocalName());
     }
 
     @Test

--- a/src/test/java/og_spipes/rest/FunctionControllerTest.java
+++ b/src/test/java/og_spipes/rest/FunctionControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import cz.cvut.kbss.jsonld.jackson.JsonLdModule;
 import cz.cvut.sforms.model.Question;
+import og_spipes.config.Constants;
 import og_spipes.model.spipes.FunctionDTO;
 import og_spipes.service.FormService;
 import og_spipes.service.FunctionService;
@@ -43,7 +44,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(locations="classpath:application.properties")
 public class FunctionControllerTest {
 
-    @Value("${scriptPaths}")
+    @Value(Constants.SCRIPTPATH_SPEL)
     private String scriptPaths;
 
     @MockBean

--- a/src/test/java/og_spipes/rest/NotificationControllerTest.java
+++ b/src/test/java/og_spipes/rest/NotificationControllerTest.java
@@ -2,7 +2,7 @@ package og_spipes.rest;
 
 import org.apache.commons.io.FileUtils;
 import org.java_websocket.WebSocket;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,7 +73,7 @@ public class NotificationControllerTest {
         file.delete();
         Thread.sleep(2000);
 
-        Assert.assertTrue(myWebSocketClient.getOnMessageCounter().get() > 1);
+        Assertions.assertTrue(myWebSocketClient.getOnMessageCounter().get() > 1);
         myWebSocketClient.close();
     }
 

--- a/src/test/java/og_spipes/rest/NotificationControllerTest.java
+++ b/src/test/java/og_spipes/rest/NotificationControllerTest.java
@@ -1,5 +1,6 @@
 package og_spipes.rest;
 
+import og_spipes.config.Constants;
 import org.apache.commons.io.FileUtils;
 import org.java_websocket.WebSocket;
 import org.junit.jupiter.api.Assertions;
@@ -31,7 +32,7 @@ public class NotificationControllerTest {
 
     private String URL;
 
-    @Value("${scriptPaths}")
+    @Value(Constants.SCRIPTPATH_SPEL)
     private String scriptPaths;
 
     @Value("${server.servlet.context-path}")

--- a/src/test/java/og_spipes/rest/ScriptControllerTest.java
+++ b/src/test/java/og_spipes/rest/ScriptControllerTest.java
@@ -3,6 +3,7 @@ package og_spipes.rest;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import cz.cvut.kbss.jsonld.jackson.JsonLdModule;
+import og_spipes.config.Constants;
 import og_spipes.model.Vocabulary;
 import og_spipes.model.dto.SHACLValidationResultDTO;
 import og_spipes.model.dto.ScriptCreateDTO;
@@ -39,7 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 public class ScriptControllerTest {
 
-    @Value("${scriptPaths}")
+    @Value(Constants.SCRIPTPATH_SPEL)
     private String scriptPaths;
 
     @Autowired

--- a/src/test/java/og_spipes/rest/ScriptControllerTest.java
+++ b/src/test/java/og_spipes/rest/ScriptControllerTest.java
@@ -1,30 +1,22 @@
 package og_spipes.rest;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
 import cz.cvut.kbss.jsonld.jackson.JsonLdModule;
 import og_spipes.model.Vocabulary;
 import og_spipes.model.dto.SHACLValidationResultDTO;
 import og_spipes.model.dto.ScriptCreateDTO;
-import og_spipes.model.dto.ScriptDTO;
-import og_spipes.model.dto.ScriptOntologyCreateDTO;
-import og_spipes.model.spipes.FunctionDTO;
 import og_spipes.model.spipes.ScriptOntologyDTO;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.impl.PropertyImpl;
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.util.FileSystemUtils;
@@ -231,8 +223,8 @@ public class ScriptControllerTest {
                 .map(x -> x.getProperty(new PropertyImpl(Vocabulary.s_p_next))).count();
         long afterExecutionCount = afterModel.listSubjectsWithProperty(new PropertyImpl(Vocabulary.s_p_next)).toList().stream()
                 .map(x -> x.getProperty(new PropertyImpl(Vocabulary.s_p_next))).count();
-        Assert.assertEquals("Before execution count is 2 of next property", 2, beforeExecutionCount);
-        Assert.assertEquals("After execution count is 3 of next property", 3, afterExecutionCount);
+        Assertions.assertEquals(2, beforeExecutionCount, "Before execution count is 2 of next property");
+        Assertions.assertEquals(3, afterExecutionCount, "After execution count is 3 of next property");
     }
 
     @Test
@@ -256,8 +248,8 @@ public class ScriptControllerTest {
         Model afterModel = ModelFactory.createDefaultModel().read(tmpScripts);
         long afterCount = afterModel.listSubjects().toList().stream()
                 .filter(x -> x.toString().equals("http://onto.fel.cvut.cz/ontologies/s-pipes/hello-world-example-0.1/bind-firstname")).count();
-        Assert.assertEquals("Bind-firstname appear in hello-world.sms.ttl", 1, beforeCount);
-        Assert.assertEquals("Bind-firstname is deleted", 0, afterCount);
+        Assertions.assertEquals(1, beforeCount, "Bind-firstname appear in hello-world.sms.ttl");
+        Assertions.assertEquals(0, afterCount, "Bind-firstname is deleted");
     }
 
     @Test
@@ -284,8 +276,8 @@ public class ScriptControllerTest {
                 .map(x -> x.getProperty(new PropertyImpl(Vocabulary.s_p_next))).count();
         long afterExecutionCount = afterModel.listSubjectsWithProperty(new PropertyImpl(Vocabulary.s_p_next)).toList().stream()
                 .map(x -> x.getProperty(new PropertyImpl(Vocabulary.s_p_next))).count();
-        Assert.assertEquals("Before deletion is count 2 of next property", 2, beforeExecutionCount);
-        Assert.assertEquals("After deletion is count 1 of next property", 1, afterExecutionCount);
+        Assertions.assertEquals(2, beforeExecutionCount, "Before deletion is count 2 of next property");
+        Assertions.assertEquals(1, afterExecutionCount, "After deletion is count 1 of next property");
     }
 
     @Test
@@ -327,7 +319,7 @@ public class ScriptControllerTest {
                 mapper.readValue(content, new TypeReference<Set<SHACLValidationResultDTO>>(){})
         );
 
-        Assert.assertEquals(1, res.size());
+        Assertions.assertEquals(1, res.size());
         SHACLValidationResultDTO resultDTO = res.get(0);
         Assertions.assertEquals("http://onto.fel.cvut.cz/ontologies/s-pipes/hello-world-example-0.6/construct-greeding", resultDTO.getModuleURI());
         Assertions.assertEquals("Violation", resultDTO.getSeverityMessage());

--- a/src/test/java/og_spipes/rest/ViewControllerTest.java
+++ b/src/test/java/og_spipes/rest/ViewControllerTest.java
@@ -2,6 +2,7 @@ package og_spipes.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import cz.cvut.kbss.jsonld.jackson.JsonLdModule;
+import og_spipes.config.Constants;
 import og_spipes.model.view.View;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.rdf4j.repository.Repository;
@@ -35,7 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 public class ViewControllerTest {
 
-    @Value("${scriptPaths}")
+    @Value(Constants.SCRIPTPATH_SPEL)
     private String scriptPaths;
 
     @Autowired

--- a/src/test/java/og_spipes/service/FormServiceTest.java
+++ b/src/test/java/og_spipes/service/FormServiceTest.java
@@ -1,6 +1,7 @@
 package og_spipes.service;
 
 import cz.cvut.sforms.model.Question;
+import og_spipes.config.Constants;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -23,7 +24,7 @@ public class FormServiceTest {
     @Autowired
     private FormService formService;
 
-    @Value("${scriptPaths}")
+    @Value(Constants.SCRIPTPATH_SPEL)
     private String scriptPaths;
 
     @BeforeEach

--- a/src/test/java/og_spipes/service/FormServiceTest.java
+++ b/src/test/java/og_spipes/service/FormServiceTest.java
@@ -1,32 +1,20 @@
 package og_spipes.service;
 
-import cz.cvut.kbss.jsonld.jackson.JsonLdModule;
 import cz.cvut.sforms.model.Question;
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.util.FileSystemUtils;
 
-import javax.xml.bind.SchemaOutputResolver;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.HashMap;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 //TODO more robust tests
 @SpringBootTest

--- a/src/test/java/og_spipes/service/FunctionServiceTest.java
+++ b/src/test/java/og_spipes/service/FunctionServiceTest.java
@@ -4,10 +4,8 @@ import og_spipes.model.spipes.FunctionDTO;
 import og_spipes.persistence.dao.ScriptDAO;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.web.client.RestTemplate;
 
@@ -17,7 +15,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/og_spipes/service/OntologyHelperTest.java
+++ b/src/test/java/og_spipes/service/OntologyHelperTest.java
@@ -1,21 +1,17 @@
 package og_spipes.service;
 
 import og_spipes.persistence.dao.ScriptDAO;
-import org.apache.jena.ontology.OntModel;
 import org.apache.jena.rdf.model.Model;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest

--- a/src/test/java/og_spipes/service/ScriptOntologyHelperTest.java
+++ b/src/test/java/og_spipes/service/ScriptOntologyHelperTest.java
@@ -1,10 +1,8 @@
 package og_spipes.service;
 
 import com.google.common.collect.Sets;
+import og_spipes.config.Constants;
 import org.apache.commons.io.FileUtils;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.impl.PropertyImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +23,7 @@ import java.util.Set;
 @SpringBootTest
 class ScriptOntologyHelperTest {
 
-    @Value("${scriptPaths}")
+    @Value(Constants.SCRIPTPATH_SPEL)
     private String[] scriptPaths;
 
     @BeforeEach

--- a/src/test/java/og_spipes/service/ScriptServiceTest.java
+++ b/src/test/java/og_spipes/service/ScriptServiceTest.java
@@ -1,5 +1,6 @@
 package og_spipes.service;
 
+import og_spipes.config.Constants;
 import og_spipes.model.spipes.Module;
 import og_spipes.model.spipes.ModuleType;
 import og_spipes.service.exception.FileExistsException;
@@ -39,7 +40,7 @@ public class ScriptServiceTest {
     @Autowired
     private ScriptService scriptService;
 
-    @Value("${scriptPaths}")
+    @Value(Constants.SCRIPTPATH_SPEL)
     private String[] scriptPaths;
 
     @BeforeEach

--- a/src/test/java/og_spipes/service/ViewServiceTest.java
+++ b/src/test/java/og_spipes/service/ViewServiceTest.java
@@ -5,10 +5,8 @@ import og_spipes.model.spipes.ModuleType;
 import og_spipes.model.view.View;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.net.URI;
@@ -16,7 +14,6 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashSet;
 
-import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/og_spipes/shacl/RulesTest.java
+++ b/src/test/java/og_spipes/shacl/RulesTest.java
@@ -1,5 +1,6 @@
 package og_spipes.shacl;
 
+import og_spipes.config.Constants;
 import og_spipes.model.dto.SHACLValidationResultDTO;
 import og_spipes.service.SHACLExecutorService;
 import org.apache.jena.rdf.model.Resource;
@@ -26,7 +27,7 @@ import java.util.stream.Collectors;
 @SpringBootTest
 public class RulesTest {
 
-    @Value("${scriptPaths}")
+    @Value(Constants.SCRIPTPATH_SPEL)
     private String[] scriptPaths;
 
     @BeforeEach


### PR DESCRIPTION
This pull-request attempts to resolve the https://github.com/kbss-cvut/s-pipes-editor-ui/issues/3 The custom parsing of `scriptPaths` is done using a SPEL expression `"#{'${scriptPaths}'.split(';')}"` in the `@Value` annotations. The SPEL expression is stored in constant `Constants.SCRIPTPATH_SPEL` and `@Value("${scriptPaths}")` are replaced by `@Value(Constants.SCRIPTPATH_SPEL)`

The test `og_spipes.config.CustomParsingScriptPathParameterTest` verifies that the parse expression works as expected.